### PR TITLE
Increase the range of Norm Threshold

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -55,7 +55,7 @@ class APG_ImYourCFGNow:
                 "model": ("MODEL",),
                 "scale": ("FLOAT", {"default": 5.0, "min": 0.0, "max": 100.0, "step": 0.1, "round": 0.01}),
                 "momentum": ("FLOAT", {"default": -0.5, "min": -1.5, "max": 0.5, "step": 0.1, "round": 0.01}),
-                "norm_threshold": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.1, "round": 0.01}),
+                "norm_threshold": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 50.0, "step": 0.5, "round": 0.01}),
                 "eta": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.1, "round": 0.01}),
             },
         }


### PR DESCRIPTION
The norm threshold refers to the r (rescaling) term in the paper, which ranges from 2.5 in EDM2-XL to 15 in Stable Diffusion XL. Current range of 0 to 1 is way too small.